### PR TITLE
fix: remove debug printlns, deduplicate RSS URL, add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 RhoMan¢er
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composeApp/src/commonMain/kotlin/dev/angussoftware/app/blog/BlogRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/angussoftware/app/blog/BlogRepository.kt
@@ -9,8 +9,6 @@ internal class BlogRepository(
             val xml = networkClient.fetchUrlText(feedUrl)
             RssParser.parse(xml, limit)
         } catch (t: Throwable) {
-            println(t.toString())
-
             emptyList()
         }
 }

--- a/composeApp/src/commonMain/kotlin/dev/angussoftware/app/screens/BlogScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/angussoftware/app/screens/BlogScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import dev.angussoftware.app.navigation.RSS_FEED_URL
 import androidx.navigation.NavHostController
 import angussoftwareapp.composeapp.generated.resources.*
 import dev.angussoftware.app.blog.BlogPost
@@ -36,21 +37,18 @@ internal fun BlogScreen(
     initialPosts: List<BlogPost>? = null,
     initialIsLoading: Boolean? = null,
 ) {
-    val feedUrl = "https://rhomancer.github.io/angus-blog-content/rss.xml"
+    val feedUrl = RSS_FEED_URL
 
     var isLoading by remember { mutableStateOf(initialIsLoading ?: true) }
     var allPosts by remember { mutableStateOf(initialPosts ?: emptyList()) }
     val pageSize = PAGE_SIZE
     var visibleCount by remember { mutableStateOf(if (initialPosts != null) minOf(pageSize, initialPosts.size) else pageSize) }
 
-    println("Fetching initial posts 0")
-
     // Skip network fetch if test data is provided
     if (initialPosts == null) {
         LaunchedEffect(feedUrl) {
             val repository = BlogRepository(feedUrl)
             // Fetch all posts once, then paginate locally
-            println("Fetching initial posts 1")
 
             allPosts = repository.fetchPosts(limit = Int.MAX_VALUE)
             // Ensure initial visible count doesn't exceed size


### PR DESCRIPTION
## Summary
- Remove debug println() from BlogScreen.kt and BlogRepository.kt
- Replace hardcoded RSS URL in BlogScreen with RSS_FEED_URL constant from NavHost (single source of truth)
- Add MIT License

## Test plan
- [ ] Build: `./gradlew assembleDebug`
- [ ] Run unit tests: `./gradlew :composeApp:testDebugUnitTest`
- [ ] Verify blog still loads (RSS URL unchanged, just deduplicated)

Fixes #30, Fixes #31, Fixes #32

👾 Generated with [Letta Code](https://letta.com)