### PR TITLE
fix: align JDK target to 17 (was 11, CI uses 23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Angus Software application for showcasing my portfolio and hosting my blog.
 ## Quick start
 
 Prerequisites
-- Java 11 (JDK 11)
+- Java 17 (JDK 17+)
 - Android Studio (latest stable) with Android SDK
 - Gradle Wrapper (included): use `gradlew` on Windows, `./gradlew` on macOS/Linux
 
@@ -183,7 +183,7 @@ This project currently depends on a private "Angus Software Theming" library. If
 The app should work with standard Compose Material3 theming if you wire colors/typography/shapes directly.
 
 ## Troubleshooting
-- Use JDK 11 (both Gradle and Android compile options are set to 11)
+- Use JDK 17+ (both Gradle and Android compile options target JVM 17)
 - If the Wasm dev server doesn’t open automatically, copy the printed URL from the Gradle task output
 - If Android instrumented tests fail to discover devices, ensure an emulator is running or a device is connected (USB debugging enabled)
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -92,7 +92,7 @@ kotlin {
 
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
         dependencies {
             androidTestImplementation(libs.androidx.ui.test.junit4.android)
@@ -217,8 +217,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 


### PR DESCRIPTION
## Summary
- Bump JVM target from 11 to 17 in compiler options
- Bump Java source/target compatibility from VERSION_11 to VERSION_17
- Update README: JDK 17+ requirement (was incorrectly stating JDK 11)

## Why
CI uses JDK 23 but build config targeted JVM 11 — inconsistent and confusing.
JVM 17 is the modern baseline for Compose Multiplatform 1.9.0 + Kotlin 2.2.10.

Fixes #34

## Test plan
- [ ] Build: `./gradlew assembleDebug`
- [ ] Verify CI still passes

👾 Generated with [Letta Code](https://letta.com)