### PR TITLE
feat: blog HTML/Markdown rendering with image support

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -142,6 +142,10 @@ kotlin {
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation(libs.androidx.navigation.compose)
             implementation(libs.angusSoftware.theming.compose)
+            implementation(libs.markdown.renderer)
+            implementation(libs.markdown.renderer.m3)
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/commonMain/kotlin/dev/angussoftware/app/blog/BlogPost.kt
+++ b/composeApp/src/commonMain/kotlin/dev/angussoftware/app/blog/BlogPost.kt
@@ -8,4 +8,5 @@ internal data class BlogPost(
     val summary: String?,
     val imageUrl: String?,
     val content: String?,
+    val contentHtml: String? = null,
 )

--- a/composeApp/src/commonMain/kotlin/dev/angussoftware/app/blog/HtmlToMarkdown.kt
+++ b/composeApp/src/commonMain/kotlin/dev/angussoftware/app/blog/HtmlToMarkdown.kt
@@ -1,0 +1,111 @@
+package dev.angussoftware.app.blog
+
+/**
+ * Converts simple HTML to Markdown so the multiplatform-markdown-renderer can render it.
+ * Handles headings, bold, italic, code, links, images, lists, paragraphs,
+ * blockquotes, and preformatted blocks.
+ */
+internal object HtmlToMarkdown {
+
+    internal fun convert(html: String): String {
+        var text = html
+
+        // Preformatted blocks: <pre>...</pre> — protect from further processing
+        val preBlocks = mutableListOf<String>()
+        text = PRE_REGEX.replace(text) { match ->
+            val code = match.groupValues[1].trim()
+            val index = preBlocks.size
+            preBlocks += "```\n$code\n```"
+            "\u0000PRE$index\u0000"
+        }
+
+        // Decode entities
+        text = text
+            .replace("&nbsp;", " ")
+            .replace("&amp;", "&")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&#39;", "'")
+
+        // Self-closing / void elements → newlines
+        text = text.replace(Regex("<br\\s*/?>", RegexOption.IGNORE_CASE), "\n")
+        text = text.replace(Regex("<hr\\s*/?>", RegexOption.IGNORE_CASE), "\n---\n")
+
+        // Headings
+        for (level in 6 downTo 1) {
+            text = Regex("<h$level[^>]*>([\\s\\S]*?)</h$level>", RegexOption.IGNORE_CASE)
+                .replace(text) { match ->
+                    val prefix = "#".repeat(level)
+                    "\n$prefix ${match.groupValues[1].trim()}\n"
+                }
+        }
+
+        // Blockquotes
+        text = Regex("<blockquote[^>]*>([\\s\\S]*?)</blockquote>", RegexOption.IGNORE_CASE)
+            .replace(text) { match ->
+                val inner = match.groupValues[1].trim()
+                inner.lineSequence().joinToString("\n") { line -> "> $line" }
+            }
+
+        // Bold / strong
+        text = text.replace(Regex("<(?:strong|b)>([\\s\\S]*?)</(?:strong|b)>", RegexOption.IGNORE_CASE)) {
+            "**${it.groupValues[1].trim()}**"
+        }
+
+        // Italic / em
+        text = text.replace(Regex("<(?:em|i)>([\\s\\S]*?)</(?:em|i)>", RegexOption.IGNORE_CASE)) {
+            "*${it.groupValues[1].trim()}*"
+        }
+
+        // Inline code (before links so <code> inside <a> works)
+        text = text.replace(Regex("<code>([\\s\\S]*?)</code>", RegexOption.IGNORE_CASE)) {
+            "`${it.groupValues[1]}`"
+        }
+
+        // Links
+        text = text.replace(Regex("<a[^>]*href=\"([^\"]+)\"[^>]*>([\\s\\S]*?)</a>", RegexOption.IGNORE_CASE)) {
+            "[${it.groupValues[2]}](${it.groupValues[1]})"
+        }
+
+        // Images
+        text = text.replace(Regex("<img[^>]*src=\"([^\"]+)\"[^>]*alt=\"([^\"]*)\"[^>]*/?>", RegexOption.IGNORE_CASE)) {
+            "![${it.groupValues[2]}](${it.groupValues[1]})"
+        }
+        text = text.replace(Regex("<img[^>]*src=\"([^\"]+)\"[^>]*/?>", RegexOption.IGNORE_CASE)) {
+            "![](${it.groupValues[1]})"
+        }
+
+        // Unordered lists
+        text = Regex("<ul[^>]*>([\\s\\S]*?)</ul>", RegexOption.IGNORE_CASE).replace(text) { match ->
+            val items = Regex("<li[^>]*>([\\s\\S]*?)</li>", RegexOption.IGNORE_CASE)
+                .findAll(match.groupValues[1])
+                .joinToString("\n") { "- ${it.groupValues[1].trim()}" }
+            "\n$items\n"
+        }
+
+        // Ordered lists
+        text = Regex("<ol[^>]*>([\\s\\S]*?)</ol>", RegexOption.IGNORE_CASE).replace(text) { match ->
+            val items = Regex("<li[^>]*>([\\s\\S]*?)</li>", RegexOption.IGNORE_CASE)
+                .findAll(match.groupValues[1])
+                .mapIndexed { idx, match -> "${idx + 1}. ${match.groupValues[1].trim()}" }
+                .joinToString("\n")
+            "\n$items\n"
+        }
+
+        // Remove remaining tags
+        text = text.replace(Regex("<[^>]+>"), "")
+
+        // Restore pre blocks
+        preBlocks.forEachIndexed { index, block ->
+            text = text.replace("\u0000PRE$index\u0000", block)
+        }
+
+        // Collapse whitespace
+        text = text.replace(Regex("\n{3,}"), "\n\n")
+
+        return text.trim()
+    }
+
+    private val PRE_REGEX = Regex("<pre[^>]*>([\\s\\S]*?)</pre>", RegexOption.IGNORE_CASE)
+}

--- a/composeApp/src/commonMain/kotlin/dev/angussoftware/app/blog/RssParser.kt
+++ b/composeApp/src/commonMain/kotlin/dev/angussoftware/app/blog/RssParser.kt
@@ -22,6 +22,7 @@ internal object RssParser {
             // Full content: prefer content:encoded, then <content> if present
             val contentRaw = extractTag(itemXml, "content:encoded") ?: extractTag(itemXml, "content")
             val contentPlain = contentRaw?.let { stripHtml(decodeXmlEntities(stripCdata(it))).trim() }
+            val contentHtml = contentRaw?.let { decodeXmlEntities(stripCdata(it)).trim() }
 
             // Summary: prefer <description>, else derive from content
             val descriptionRaw = extractTag(itemXml, "description")
@@ -41,6 +42,7 @@ internal object RssParser {
                     summary = summary,
                     imageUrl = imageUrl,
                     content = contentPlain,
+                    contentHtml = contentHtml,
                 )
         }
         return posts

--- a/composeApp/src/commonMain/kotlin/dev/angussoftware/app/screens/BlogPostScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/angussoftware/app/screens/BlogPostScreen.kt
@@ -11,11 +11,16 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import angussoftwareapp.composeapp.generated.resources.*
+import coil3.compose.AsyncImage
+import com.mikepenz.markdown.compose.Markdown
+import com.mikepenz.markdown.model.markdownColor
 import dev.angussoftware.app.blog.BlogPost
+import dev.angussoftware.app.blog.HtmlToMarkdown
 import dev.angussoftware.app.navigation.LocalNavigationBarHeight
 import dev.angussoftware.app.ui.utils.currentWindowAdaptiveInfo
 import org.jetbrains.compose.resources.stringResource
@@ -91,23 +96,28 @@ internal fun BlogPostScreen(
                 )
             }
             if (!blogPost.imageUrl.isNullOrBlank()) {
-                Box(
+                AsyncImage(
+                    model = blogPost.imageUrl,
+                    contentDescription = blogPost.title,
                     modifier =
                         Modifier
                             .fillMaxWidth()
                             .height(200.dp)
                             .padding(top = 12.dp)
                             .background(MaterialTheme.colorScheme.surfaceVariant),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = stringResource(Res.string.ui_image_placeholder),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+                    contentScale = ContentScale.Crop,
+                )
             }
-            if (!blogPost.content.isNullOrBlank()) {
+            if (!blogPost.contentHtml.isNullOrBlank()) {
+                val markdownText = HtmlToMarkdown.convert(blogPost.contentHtml!!)
+                Markdown(
+                    content = markdownText,
+                    colors = markdownColor(
+                        text = MaterialTheme.colorScheme.onSurface,
+                    ),
+                    modifier = Modifier.padding(top = 12.dp),
+                )
+            } else if (!blogPost.content.isNullOrBlank()) {
                 Text(
                     text = blogPost.content!!,
                     style = MaterialTheme.typography.bodyLarge,

--- a/composeApp/src/commonMain/kotlin/dev/angussoftware/app/screens/BlogPostScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/angussoftware/app/screens/BlogPostScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.unit.dp
 import angussoftwareapp.composeapp.generated.resources.*
 import coil3.compose.AsyncImage
 import com.mikepenz.markdown.compose.Markdown
-import com.mikepenz.markdown.model.markdownColor
 import dev.angussoftware.app.blog.BlogPost
 import dev.angussoftware.app.blog.HtmlToMarkdown
 import dev.angussoftware.app.navigation.LocalNavigationBarHeight
@@ -112,9 +111,6 @@ internal fun BlogPostScreen(
                 val markdownText = HtmlToMarkdown.convert(blogPost.contentHtml!!)
                 Markdown(
                     content = markdownText,
-                    colors = markdownColor(
-                        text = MaterialTheme.colorScheme.onSurface,
-                    ),
                     modifier = Modifier.padding(top = 12.dp),
                 )
             } else if (!blogPost.content.isNullOrBlank()) {

--- a/composeApp/src/commonMain/kotlin/dev/angussoftware/app/screens/BlogScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/angussoftware/app/screens/BlogScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
@@ -21,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import angussoftwareapp.composeapp.generated.resources.*
+import coil3.compose.AsyncImage
 import dev.angussoftware.app.blog.BlogPost
 import dev.angussoftware.app.blog.BlogUiState
 import dev.angussoftware.app.blog.BlogViewModel
@@ -469,21 +471,17 @@ private fun BlogScreenWithTestData(
                                     )
                                 }
                                 if (!post.imageUrl.isNullOrBlank()) {
-                                    Box(
+                                    AsyncImage(
+                                        model = post.imageUrl,
+                                        contentDescription = post.title,
                                         modifier =
                                             Modifier
                                                 .fillMaxWidth()
                                                 .height(160.dp)
                                                 .padding(top = 8.dp)
                                                 .background(MaterialTheme.colorScheme.surfaceVariant),
-                                        contentAlignment = Alignment.Center,
-                                    ) {
-                                        Text(
-                                            text = "Image placeholder",
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    }
+                                        contentScale = ContentScale.Crop,
+                                    )
                                 }
                             }
                         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,8 @@ uiTestJunit4Android = "1.9.4"
 uiTestManifest = "1.9.4"
 sonar = "7.0.1.6134"
 jacoco = "0.9.0.M1"
+markdownRenderer = "0.40.2"
+coil = "3.0.4"
 
 [libraries]
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "uiTestManifest" }
@@ -30,6 +32,10 @@ androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecyc
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "nav_version" }
 angusSoftware-theming-compose = { module = "com.angussoftware.theming:theming-compose", version.ref = "angusSoftware-theming" }
+markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "markdownRenderer" }
+markdown-renderer-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Add multiplatform-markdown-renderer 0.40.2 for rich blog post rendering
- Add Coil 3.0.4 for async image loading
- Create `HtmlToMarkdown.kt` converter to handle raw HTML from RSS
- Preserve raw HTML in `RssParser.kt` (was being stripped)
- Replace image placeholders with actual rendered images in `BlogPostScreen.kt`

Fixes #28

## Test plan
- [ ] Build verification (blocked on GPR token renewal)
- [ ] Manual test: open blog screen, verify posts render with formatting + images

👾 Generated with [Letta Code](https://letta.com)