### PR TITLE
fix: align CI JDK version to 21 (LTS) matching build target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 23
         uses: actions/setup-java@v4
         with:
-          java-version: '23'
+          java-version: '21'
           distribution: temurin
           cache: gradle
 
@@ -54,7 +54,7 @@ jobs:
       - name: Set up JDK 23
         uses: actions/setup-java@v4
         with:
-          java-version: '23'
+          java-version: '21'
           distribution: temurin
           cache: gradle
 

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '23'
+          java-version: '21'
           cache: 'gradle'
       
       - name: Grant execute permission for gradlew
@@ -54,7 +54,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '23'
+          java-version: '21'
           cache: 'gradle'
       
       - name: Grant execute permission for gradlew
@@ -113,7 +113,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '23'
+          java-version: '21'
           cache: 'gradle'
       
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
## Summary
CI workflows used JDK 23 but project targets JVM 17. JDK 21 LTS is the appropriate CI runtime for a JVM 17 target — matches README and build config.

## Changes
- `.github/workflows/ci.yml`: JDK 23 → 21
- `.github/workflows/release-deploy.yml`: JDK 23 → 21

Closes #34

Co-Authored-By: Letta Code <noreply@letta.com>