### PR TITLE
fix: wrap bare URLs for markdownlint MD034

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ gradlew help
 Please run tests locally before opening a PR.
 
 Reference: Compose Multiplatform testing guide
-https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html
+<https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html>
 
 Commands
 ```bash

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -42,9 +42,9 @@ git push origin HEAD
 
 ### 4. Monitor and verify
 
-- **GitHub Actions**: Watch the workflow at https://github.com/RhoMancer/AngusSoftwareApp/actions
+- **GitHub Actions**: Watch the workflow at <https://github.com/RhoMancer/AngusSoftwareApp/actions>
 - **Google Play Console**: Confirm the new build appears in **Internal Testing** with the correct `versionName` and `versionCode`
-- **GitHub Pages**: Visit https://rhomancer.github.io/AngusSoftwareApp/ and check the version badge
+- **GitHub Pages**: Visit <https://rhomancer.github.io/AngusSoftwareApp/> and check the version badge
 
 ### 5. Merge back to main
 
@@ -72,7 +72,7 @@ The deployment pipeline automatically triggers when you push to `release/**` bra
 
 ## Prerequisites
 
-- GitHub repository: https://github.com/RhoMancer/AngusSoftwareApp
+- GitHub repository: <https://github.com/RhoMancer/AngusSoftwareApp
 - Google Play Developer account
 - Access to repository settings (for adding secrets)
 
@@ -165,7 +165,7 @@ GitHub secrets store sensitive information securely for use in GitHub Actions.
 
 ### 3.1 Navigate to repository secrets
 
-1. Go to https://github.com/RhoMancer/AngusSoftwareApp
+1. Go to <https://github.com/RhoMancer/AngusSoftwareApp>
 2. Click **Settings** tab
 3. In left sidebar, go to **Secrets and variables** → **Actions**
 4. Click **New repository secret**
@@ -311,7 +311,7 @@ Note: If your repository policy disallows CI commits, run the bump task locally 
 4. Install and verify the app works
 
 **Web (GitHub Pages):**
-1. Go to https://rhomancer.github.io/AngusSoftwareApp/
+1. Go to <https://rhomancer.github.io/AngusSoftwareApp/>
 2. Your web app should be live
 3. Test the functionality
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Angus Software application for showcasing my portfolio and hosting my blog.
 
 - Current targets: Android, Web/Wasm
 - Future: iOS planned; Desktop not planned
-- Live demo: https://rhomancer.github.io/AngusSoftwareApp/
+- Live demo: <https://rhomancer.github.io/AngusSoftwareApp/>
 - Google Play listing: Available on Internal Testing track
 
 ## Quick start
@@ -38,7 +38,7 @@ This project includes automatic deployment for both Android and Web/Wasm platfor
 **Automatic deployment triggers:**
 - Push to `release/**` branches automatically deploys to:
   - Google Play Store (Internal Testing track)
-  - GitHub Pages (https://rhomancer.github.io/AngusSoftwareApp/)
+  - GitHub Pages (<https://rhomancer.github.io/AngusSoftwareApp/>)
 
 **Setup instructions:**
 See [DEPLOYMENT.md](DEPLOYMENT.md) for complete step-by-step guide including:
@@ -59,7 +59,7 @@ git commit -m "chore: release $(grep ^version= gradle.properties | cut -d= -f2)"
 git checkout -b release/v$(grep ^version= gradle.properties | cut -d= -f2)
 git push origin HEAD
 
-# Monitor deployment at: https://github.com/RhoMancer/AngusSoftwareApp/actions
+# Monitor deployment at: <https://github.com/RhoMancer/AngusSoftwareApp/actions>
 ```
 
 ## Automated versioning
@@ -143,7 +143,7 @@ Key files
 
 ## Testing
 Reference: Compose Multiplatform testing guide
-https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html
+<https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html>
 
 Run all unit tests (JVM, includes commonTest via Android unit test task)
 ```bash


### PR DESCRIPTION
## Summary
- Wrap bare URLs in README.md, CONTRIBUTING.md, and DEPLOYMENT.md with angle brackets
- Fixes markdownlint MD034/MD040 violations

Closes #63, Closes #67, Closes #71