### PR TITLE
ci: add Android instrumented test workflow (closes #74)

### DIFF
--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [develop, master]
 
+permissions:
+  contents: read
+
 jobs:
   instrumented-test:
     name: Android Instrumented Tests

--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -1,0 +1,57 @@
+name: Instrumented Tests
+
+on:
+  pull_request:
+    branches: [develop, master]
+  push:
+    branches: [develop, master]
+
+jobs:
+  instrumented-test:
+    name: Android Instrumented Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: temurin
+          cache: gradle
+
+      - name: Configure GPR credentials
+        run: |
+          mkdir -p ~/.gradle
+          echo "githubUser=${{ github.actor }}" >> ~/.gradle/gradle.properties
+          echo "githubToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> ~/.gradle/gradle.properties
+          echo "githubOwner=RhoMancer" >> ~/.gradle/gradle.properties
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          profile: pixel_6
+          heap-size: 512M
+          ram-size: 4096M
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          disable-animations: true
+          script: ./gradlew :composeApp:connectedDebugAndroidTest
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-test-results
+          path: '**/build/reports/androidTests/connected/'

--- a/.github/workflows/vibecheck.yml
+++ b/.github/workflows/vibecheck.yml
@@ -29,5 +29,5 @@ jobs:
         uses: WolffM/vibecheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          severity_threshold: "low"
-          confidence_threshold: "medium"
+          severity_threshold: low
+          confidence_threshold: medium


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow for running Android instrumented tests on an API 34 emulator.

## Changes
- New `.github/workflows/instrumented-tests.yml`
- Uses `reactivecircus/android-emulator-runner@v2` with API 34 x86_64
- KVM enabled for hardware acceleration
- Runs on push/PR to develop and master
- Uploads test results as artifacts

## Why
Instrumented tests exist in `composeApp/src/androidInstrumentedTest/` but have never run in CI. This catches UI regressions and Compose rendering issues that JVM tests can't detect.

Closes #74

## Test plan
- [ ] Workflow triggers on this PR
- [ ] Emulator boots and tests pass
- [ ] If tests fail, check artifact for details