### PR TITLE
fix: scope ci.yml permissions to contents:read (closes #81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [develop, master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Test


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to ci.yml to satisfy Checkov CKV2_GHA_1
- Default GitHub Actions permissions are write-all — this scopes to minimum needed

Closes #81