### PR TITLE
fix: remove redundant quotes in vibecheck.yml (closes #83)

### DIFF
--- a/.github/workflows/vibecheck.yml
+++ b/.github/workflows/vibecheck.yml
@@ -29,5 +29,5 @@ jobs:
         uses: WolffM/vibecheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          severity_threshold: "low"
-          confidence_threshold: "medium"
+          severity_threshold: low
+          confidence_threshold: medium


### PR DESCRIPTION
## Summary
- Remove redundant double quotes from `severity_threshold` and `confidence_threshold` in vibecheck.yml
- yamllint `quoted-strings` rule: string values should not be redundantly quoted

Closes #83