### PR TITLE
fix: strip comments from version.txt when displaying version badge

### DIFF
--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -38,7 +38,8 @@
         fetch('version.txt', { cache: 'no-store' })
             .then(r => r.ok ? r.text() : Promise.reject(r.status))
             .then(t => {
-                document.getElementById('version-text').textContent = (t || '').trim();
+                const version = (t || '').split('\n').find(l => l.trim() && !l.trim().startsWith('#'));
+                document.getElementById('version-text').textContent = version ? version.trim() : '';
             })
             .catch(() => {
                 // Hide badge if not available (e.g., local dev before build runs)


### PR DESCRIPTION
The version badge at the bottom of the website was showing the entire version.txt content including comments like \`# AUTO-GENERATED at build time...\`.

Fix: parse version.txt to extract only the first non-comment, non-empty line (the actual version number).

Before: \`Version: # auto-genetated at build time... 1.24\`
After: \`Version: 1.2.4\`