### PR TITLE
fix: remove redundant quotes from DISPLAY in emulator.yml

### DIFF
--- a/.woodpecker/emulator.yml
+++ b/.woodpecker/emulator.yml
@@ -11,7 +11,7 @@ steps:
       ANDROID_SDK_ROOT: /opt/android-sdk
       ANDROID_AVD_HOME: /root/.android/avd
       GRADLE_USER_HOME: /root/.gradle
-      DISPLAY: ":99"
+      DISPLAY: :99
     commands:
       - |
         export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH"


### PR DESCRIPTION
## Summary
- Remove redundant quotes from `DISPLAY: ":99"` → `DISPLAY: :99` in `.woodpecker/emulator.yml`
- Both forms parse identically in YAML; yamllint `quoted-strings` rule flagged the quotes as unnecessary

Closes #112

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>