### PR TITLE
ci: remove unified coverage tollgate for single-module project

### DIFF
--- a/.woodpecker/build.yml
+++ b/.woodpecker/build.yml
@@ -26,14 +26,7 @@ steps:
       - chmod +x gradlew
       # Run tests + Kover coverage
       - ./gradlew --no-daemon :composeApp:testDebugUnitTest :composeApp:koverXmlReport :composeApp:koverVerify
-      # Coverage tollgate (CI-only: PRs only, skip on push)
-      - |
-        if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
-          git clone https://x-access-token:${GPR_TOKEN}@github.com/RhoMancer/ci-scripts.git /tmp/ci-scripts
-          bash /tmp/ci-scripts/scripts/check-unified-coverage.sh
-        else
-          echo "Coverage tollgate skipped (push event)"
-        fi
+      # Coverage enforced by koverVerify above (single-module project, no shared/ module)
     environment:
       GRADLE_USER_HOME: /root/.gradle
       ANDROID_HOME: /opt/android-sdk


### PR DESCRIPTION
The `check-unified-coverage.sh` script expects `shared/build/reports/coverage/UNIFIED_COVERAGE.md` which does not exist — AngusSoftwareApp is a single-module project (`composeApp/`) without a `shared/` module.

Coverage is still enforced by `koverVerify` in the Gradle build step. The shell script tollgate was cargo-culted from Angus-Tasks/Theming which have multi-module layouts.

Fixes the false CI failures on PR #121 and #122.