### PR TITLE
chore: switch to trunk-based development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop, master]
+    branches: [master]
   push:
-    branches: [develop, master]
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -2,9 +2,9 @@ name: Instrumented Tests
 
 on:
   pull_request:
-    branches: [develop, master]
+    branches: [master]
   push:
-    branches: [develop, master]
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/vibecheck.yml
+++ b/.github/workflows/vibecheck.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '0 9 * * 1'
   pull_request:
-    branches: [develop, master]
+    branches: [master]
 
 permissions:
   contents: read

--- a/.woodpecker/build.yml
+++ b/.woodpecker/build.yml
@@ -1,6 +1,6 @@
 when:
   - event: [push, pull_request]
-    branch: [master, main, develop]
+    branch: [master, main]
 
 steps:
   build:

--- a/.woodpecker/emulator.yml
+++ b/.woodpecker/emulator.yml
@@ -1,6 +1,6 @@
 when:
   - event: [push, pull_request]
-    branch: [master, main, develop]
+    branch: [master, main]
 
 steps:
   instrumented-tests:


### PR DESCRIPTION
Remove develop branch references from all CI configs. Deleted develop branch (was 79 commits behind master, no path to reconcile). All PRs now target master.