### PR TITLE
ci: fix vibeCheck debug workflow to use fork

### DIFF
--- a/.github/workflows/vibecheck-debug.yml
+++ b/.github/workflows/vibecheck-debug.yml
@@ -1,0 +1,30 @@
+name: vibeCheck Debug
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: RhoMancer/vibecheck@fix/kmp-and-arg-names
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          severity_threshold: "low"
+          confidence_threshold: "low"
+          skip_issues: "true"
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: vibecheck-results
+          path: .vibecheck-output/


### PR DESCRIPTION
Fixes corrupted debug workflow. Uses RhoMancer/vibecheck@fix/kmp-and-arg-names.